### PR TITLE
Navbar register option

### DIFF
--- a/fact-bounty-client/src/shared/components/TopNavBar.js
+++ b/fact-bounty-client/src/shared/components/TopNavBar.js
@@ -66,10 +66,14 @@ class TopNavBar extends Component {
 					</Button>
 					<Menu id="simple-menu" anchorEl={anchorEl}
 						  open={Boolean(anchorEl)} onClose={this.handleClose}>
-						<Link to="/login">
+						<Link to="/login" style={styles.link}>
 							<MenuItem>Login</MenuItem>
 						</Link>
+						<Link to="/register" style={styles.link}>
+							<MenuItem>Register</MenuItem>
+						</Link>
 					</Menu>
+					
 				</Toolbar>
 			</AppBar>
 		)

--- a/fact-bounty-server/package-lock.json
+++ b/fact-bounty-server/package-lock.json
@@ -1401,7 +1401,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1816,7 +1817,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1872,6 +1874,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1915,12 +1918,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Earlier register route can only be accessed by manually entering that route. Now user can register directly through register button in navbar

**Closing issues**

Closes #105 