### PR TITLE
.travis.yml file added with python versions(3.5 and 3.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+# Config file for automatic testing at travis-ci.org
+language: python
+env:
+- FLASK_APP=app.py FLASK_DEBUG=1
+python:
+  - 3.5
+  - 3.6
+install:
+  - pip install -r fact-bounty-flask/requirements.txt
+
+script: 
+    - cd fact-bounty-flask
+    - flask test


### PR DESCRIPTION
@ivantha 
Travis CI integrated with the testing build of two python versions 3.5 and 3.6
#145 