### PR TITLE
Fixes Issue: #142 - Server side validation for Name in Signup form

### DIFF
--- a/fact-bounty-server/validation/register.js
+++ b/fact-bounty-server/validation/register.js
@@ -15,7 +15,7 @@ module.exports = function validateRegisterInput(data) {
 		errors.name = 'Name field is required'
 	}
 
-	if(Validator.isAlpha(data.name)){
+	if(!Validator.isAlpha(data.name)){
 		errors.name = 'Name field can only have alphabets.'
 	}
 

--- a/fact-bounty-server/validation/register.js
+++ b/fact-bounty-server/validation/register.js
@@ -15,6 +15,10 @@ module.exports = function validateRegisterInput(data) {
 		errors.name = 'Name field is required'
 	}
 
+	if(Validator.isAlpha(data.name)){
+		errors.name = 'Name field can only have alphabets.'
+	}
+
 	// Email checks
 	if (Validator.isEmpty(data.email)) {
 		errors.email = 'Email field is required'


### PR DESCRIPTION
Closes #142 

This PR will add server-side validation for #142 and return an appropriate error message. 

Screenshot: 

![alt text](https://i.ibb.co/tLdQYHJ/Screenshot-from-2019-03-15-13-54-13.png "Name should accept only alphabets")