### PR TITLE
user_name added in jwt_token payload

### DIFF
--- a/fact-bounty-flask/api/controllers/users.py
+++ b/fact-bounty-flask/api/controllers/users.py
@@ -60,7 +60,7 @@ class Login(MethodView):
 			# Try to authenticate the found user using their password
 			if user and user.verify_password(data['password']):
 				# Generate the access token. This will be used as the authorization header
-				access_token = user.generate_auth_token(user_id=user.id, expiration=3600)
+				access_token = user.generate_auth_token(user_id=user.id, user_name=user.name, expiration=3600)
 				if access_token:
 					response = {
 						'message': 'You logged in successfully.',

--- a/fact-bounty-flask/api/models/user.py
+++ b/fact-bounty-flask/api/models/user.py
@@ -39,7 +39,7 @@ class User(db.Model):
         """
         return '<User %r>' % self.name
 
-    def generate_auth_token(self, expiration, user_id):
+    def generate_auth_token(self, expiration, user_id,user_name):
         """
         Generate authorization token
 
@@ -49,7 +49,8 @@ class User(db.Model):
             payload = {
                 'exp': datetime.utcnow() + timedelta(seconds=expiration),
                 'iat': datetime.utcnow(),
-                'sub': user_id
+                'sub': user_id,
+                'name':user_name
             }
             # create the byte string token using the payload and the SECRET key
             jwt_string = jwt.encode(


### PR DESCRIPTION
Now user data can be used in the client side as `name` is added in the token data.
Fixes #196 
@ivantha 

**Thanks**