### PR TITLE
fix: generalized the text on oauth buttons

### DIFF
--- a/fact-bounty-client/package-lock.json
+++ b/fact-bounty-client/package-lock.json
@@ -3118,11 +3118,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3135,15 +3137,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3246,7 +3251,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3256,6 +3262,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3268,17 +3275,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3295,6 +3305,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3367,7 +3378,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3377,6 +3389,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3482,6 +3495,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -17053,6 +17067,11 @@
         "@types/react": "*",
         "prop-types": "^15.6.0"
       }
+    },
+    "react-icons": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.5.0.tgz",
+      "integrity": "sha512-LuKUcavgPWjPrRkIdNbsGw8LqcnhfNN0AGCtU4Td1UkOenJSIWbYppSJrD6zi/TDZOHtTs9opu6ZKB/NFWk21g=="
     },
     "react-infinite-scroller": {
       "version": "1.2.4",

--- a/fact-bounty-client/src/pages/login/components/Login.js
+++ b/fact-bounty-client/src/pages/login/components/Login.js
@@ -281,7 +281,7 @@ class Login extends Component {
                 OR
               </span>
             </div>
-            <OauthContainer />
+            <OauthContainer button_type="Login" />
           </form>
           <p>
             Don&apos;t have an account?&nbsp;

--- a/fact-bounty-client/src/pages/register/components/Register.js
+++ b/fact-bounty-client/src/pages/register/components/Register.js
@@ -356,7 +356,7 @@ class Register extends Component {
                 OR
               </span>
             </div>
-            <OauthContainer />
+            <OauthContainer button_type="Signup" />
           </form>
           <p>
             Already have an account?{" "}

--- a/fact-bounty-client/src/shared/OAuthContainer/FacebookContainer.js
+++ b/fact-bounty-client/src/shared/OAuthContainer/FacebookContainer.js
@@ -33,7 +33,13 @@ class FacebookContainer extends React.Component {
       <FacebookLogin
         appId={process.env.REACT_APP_FACEBOOK_CLIENT_ID}
         cssClass="fbauth"
-        textButton="Login with facebook"
+        textButton={
+          this.props.button_type === "Signup"
+            ? "Signup with Facebook"
+            : this.props.button_type === "Login"
+            ? "Login with Facebook"
+            : null
+        }
         fields="name,email,picture.width(400).height(400)"
         callback={this.responseFacebook}
         icon={
@@ -54,7 +60,8 @@ class FacebookContainer extends React.Component {
 }
 
 FacebookContainer.propTypes = {
-  OauthUser: PropTypes.func.isRequired
+  OauthUser: PropTypes.func.isRequired,
+  button_type: PropTypes.string
 };
 
 const mapStateToProps = null;

--- a/fact-bounty-client/src/shared/OAuthContainer/GoogleContainer.js
+++ b/fact-bounty-client/src/shared/OAuthContainer/GoogleContainer.js
@@ -56,7 +56,11 @@ class GoogleContainer extends Component {
                 src="https://upload.wikimedia.org/wikipedia/commons/5/53/Google_%22G%22_Logo.svg"
                 alt="icon"
               />
-              Login with Google
+              {this.props.button_type === "Signup"
+                ? "Signup with Google"
+                : this.props.button_type === "Login"
+                ? "Login with Google"
+                : null}
             </Button>
           )}
           clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID}
@@ -69,7 +73,8 @@ class GoogleContainer extends Component {
 }
 
 GoogleContainer.propTypes = {
-  OauthUser: PropTypes.func.isRequired
+  OauthUser: PropTypes.func.isRequired,
+  button_type: PropTypes.string
 };
 
 const mapStateToProps = null;

--- a/fact-bounty-client/src/shared/OAuthContainer/index.js
+++ b/fact-bounty-client/src/shared/OAuthContainer/index.js
@@ -1,14 +1,22 @@
-import React from "react";
-
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FacebookContainer from "./FacebookContainer";
 import GoogleContainer from "./GoogleContainer";
 import "./index.css";
 
-const OauthContainer = () => (
-  <div className="socialIconsSignup">
-    <FacebookContainer />
-    <GoogleContainer />
-  </div>
-);
+class OauthContainer extends Component {
+  render() {
+    return (
+      <div className="socialIconsSignup">
+        <FacebookContainer button_type={this.props.button_type} />
+        <GoogleContainer button_type={this.props.button_type} />
+      </div>
+    );
+  }
+}
+
+OauthContainer.propTypes = {
+  button_type: PropTypes.string
+};
 
 export default OauthContainer;


### PR DESCRIPTION
Implemented a generalized way for text on buttons i.e when it is on Login or Register form I passed `prop` variable named `button_type` which will give a string named ``` "Login" or "Signup" ``` which is used in further containers to determine button text.

@ivantha @root5533 
Please review!
Fixes #233 