### PR TITLE
date in proper format

### DIFF
--- a/fact-bounty-client/src/pages/main/components/Post.js
+++ b/fact-bounty-client/src/pages/main/components/Post.js
@@ -140,7 +140,9 @@ class Post extends Component {
                 </div>
                 <div className="details">
                   <div className="title">{post.title}</div>
-                  <div className="date">{post.date_added.$date}</div>
+                  <div className="date">
+                    {new Date(post.date_added.$date).toUTCString()}
+                  </div>
                   <div className="content">
                     {content}
                     {post.content.length > 320 ? "..." : ""}


### PR DESCRIPTION
The date is now displayed in a proper format

![Screenshot from 2019-03-26 08-02-10](https://user-images.githubusercontent.com/10571896/54967443-89b04080-4f9d-11e9-8268-b882cf3b0854.png)

closes #249 