### PR TITLE
feat: crawl news of particular date or today news

### DIFF
--- a/Crawlers/news_sites/spiders/adaDerana.py
+++ b/Crawlers/news_sites/spiders/adaDerana.py
@@ -11,6 +11,12 @@ class adaDeranaSpider(scrapy.Spider):
     start_urls = ['http://www.adaderana.lk/hot-news', 'http://www.adaderana.lk/sports-news',
                   'http://www.adaderana.lk/entertainment-news', 'http://www.adaderana.lk/technology-news']
 
+    def __init__(self, date=None):
+        if date is not None:
+            self.dateToMatch = dparser.parse(date,fuzzy=True).date()
+        else:
+            self.dateToMatch = None
+
     def parse(self, response):
         for news_url in response.css('.hidden-xs a::attr("href")').extract():
             yield response.follow(news_url, callback=self.parse_article)
@@ -21,16 +27,21 @@ class adaDeranaSpider(scrapy.Spider):
         item['author'] = 'http://www.adaderana.lk'
         item['title'] = response.css('h1::text').extract_first()
         date  = response.css('.news-datestamp::text').extract_first()
-        if date is not None:
-            date = date.replace("\r", "")
-            date = date.replace("\t", "")
-            date = date.replace("\n", "")
-            date = dparser.parse(date,fuzzy=True)
-            date = date.strftime("%d %B, %Y")
+        if date is None:
+            return
+        
+        date = date.replace("\r", "")
+        date = date.replace("\t", "")
+        date = date.replace("\n", "")
+        date = dparser.parse(date,fuzzy=True).date()
+        
+        # don't add news if we are using dateToMatch and date of news 
+        if self.dateToMatch is not None and self.dateToMatch != date:
+            return
 
-        item['date'] = date
+        item['date'] = date.strftime("%d %B, %Y")
         item['imageLink'] = response.css('.news-banner .img-responsive::attr(src)').extract_first()
         item['source'] = 'http://www.adaderana.lk'
-        item['content'] = ' \n '.join(response.css('.news-content p::text').extract())
+        item['content'] = '\n'.join(response.css('.news-content p::text').extract())
 
         yield item

--- a/Crawlers/news_sites/spiders/adaDerana.py
+++ b/Crawlers/news_sites/spiders/adaDerana.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import scrapy
-from scrapy.http import Request
+import dateutil.parser as dparser
 
 from news_sites.items import NewsSitesItem
 
@@ -20,7 +20,15 @@ class adaDeranaSpider(scrapy.Spider):
 
         item['author'] = 'http://www.adaderana.lk'
         item['title'] = response.css('h1::text').extract_first()
-        item['date']  = response.css('.news-datestamp::text').extract_first()
+        date  = response.css('.news-datestamp::text').extract_first()
+        if date is not None:
+            date = date.replace("\r", "")
+            date = date.replace("\t", "")
+            date = date.replace("\n", "")
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+
+        item['date'] = date
         item['imageLink'] = response.css('.news-banner .img-responsive::attr(src)').extract_first()
         item['source'] = 'http://www.adaderana.lk'
         item['content'] = ' \n '.join(response.css('.news-content p::text').extract())

--- a/Crawlers/news_sites/spiders/am.py
+++ b/Crawlers/news_sites/spiders/am.py
@@ -11,6 +11,13 @@ class amSpider(scrapy.Spider):
     start_urls = ['http://am.lk/local-news', 'http://am.lk/si-international',
                   'http://am.lk/si-economy', 'http://am.lk/sports']
 
+    
+    def __init__(self, date=None):
+        if date is not None:
+            self.dateToMatch = dparser.parse(date).date()
+        else:
+            self.dateToMatch = None
+
     def parse(self, response):
         for news_url in response.css('.catItemTitle a ::attr("href")').extract():
             yield response.follow(news_url, callback=self.parse_article)
@@ -26,14 +33,19 @@ class amSpider(scrapy.Spider):
         item['author'] = 'http://am.lk'
         item['title'] = response.css('.itemTitle::text').extract_first()
         date  = response.css('.itemDateCreated::text').extract()[1]
-        if date is not None:
-            date = date.replace("\r", "")
-            date = date.replace("\t", "")
-            date = date.replace("\n", "")
-            date = dparser.parse(date,fuzzy=True)
-            date = date.strftime("%d %B, %Y")
+        if date is None:
+            return
+        
+        date = date.replace("\r", "")
+        date = date.replace("\t", "")
+        date = date.replace("\n", "")
+        date = dparser.parse(date,fuzzy=True).date()
+        
+        # don't add news if we are using dateToMatch and date of news 
+        if self.dateToMatch is not None and self.dateToMatch != date:
+            return
 
-        item['date'] = date
+        item['date'] = date.strftime("%d %B, %Y")
         item['imageLink'] = response.css('#k2Container img::attr(src)').extract_first()
         item['source'] = 'http://am.lk'
         item['content'] = ' \n '.join(response.css('#k2Container p::text').extract())

--- a/Crawlers/news_sites/spiders/am.py
+++ b/Crawlers/news_sites/spiders/am.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import dateutil.parser as dparser
 
 from news_sites.items import NewsSitesItem
 
@@ -24,7 +25,15 @@ class amSpider(scrapy.Spider):
 
         item['author'] = 'http://am.lk'
         item['title'] = response.css('.itemTitle::text').extract_first()
-        item['date']  = response.css('.itemDateCreated::text').extract()[1]
+        date  = response.css('.itemDateCreated::text').extract()[1]
+        if date is not None:
+            date = date.replace("\r", "")
+            date = date.replace("\t", "")
+            date = date.replace("\n", "")
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+
+        item['date'] = date
         item['imageLink'] = response.css('#k2Container img::attr(src)').extract_first()
         item['source'] = 'http://am.lk'
         item['content'] = ' \n '.join(response.css('#k2Container p::text').extract())

--- a/Crawlers/news_sites/spiders/bizDerana.py
+++ b/Crawlers/news_sites/spiders/bizDerana.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import scrapy
-# from urllib.parse import urljoin
 from scrapy.http import Request
+import dateutil.parser as dparser
 
 from ..items import NewsSitesItem
 
@@ -28,9 +28,13 @@ class BizadaDeranaSpider(scrapy.Spider):
 
         item['author'] = 'bizada'
         item['title'] = response.css('.news-header h3::text').extract_first()
-        item['date']  = response.css('.news-date::text').extract()[1]
+        date  = response.css('.news-date::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = response.css('.wp-post-image::attr(src)').extract_first()
-        item['source'] = 'http://bizenglish.adaderana.lk'
+        item['source'] = response.url
         item['content'] = ' \n '.join(response.css('.news-text::text').extract())
 
         yield item

--- a/Crawlers/news_sites/spiders/dailymirror.py
+++ b/Crawlers/news_sites/spiders/dailymirror.py
@@ -1,13 +1,16 @@
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
+
 class DailymirrorSpider(scrapy.Spider):
-    name = "DailyMirror"
+    name = "dailymirror"
     start_urls = ['http://www.dailymirror.lk/']
 
     def parse(self, response):
         categories = response.xpath('//*[contains(concat( " ", @class, " " ), concat( " ", "hrbo", " " ))]')
-        categories = categories.xpath('../@href')
+        categories = categories.xpath('../@href').extract()
         for category in categories:
             try:
                 int(category.split('/')[-1])
@@ -17,21 +20,29 @@ class DailymirrorSpider(scrapy.Spider):
             yield response.follow(category, callback=self.parse_category)
     
     def parse_category(self, response):
-        for news_url in response.css('.cat-hd-tx::attr("href")').extract():
+        news_urls = response.css('.cat-hd-tx')
+        news_urls = news_urls.xpath('../@href').extract()
+        for news_url in news_urls:
             yield response.follow(news_url, callback=self.parse_article)
         
         next_page = response.css('.page-numbers::attr("href")').extract_first()
         if next_page is not None:
-            yield response.follow(next_page, callback=self.parse)
+            yield response.follow(next_page, callback=self.parse_category)
 
     def parse_article(self, response):
         item = NewsSitesItem()
 
-        item['author'] = 'DailyMirror'
+        author = response.css('strong::text').extract_first().replace('(', '').replace(')', '')
+        item['author'] = author
         item['title'] = response.css('.innerheader::text').extract_first()
-        item['date']  = response.css('.col-12 .gtime::text').extract()[1]
+        # extract date component and generalize it
+        date  = response.css('.col-12 .gtime::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = None
         item['source'] = 'http://www.dailymirror.lk'
-        item['content'] = ' \n '.join(response.css('.inner-content p::text').extract())
+        item['content'] = '\n'.join(response.css('.inner-content p::text').extract())
 
         yield item

--- a/Crawlers/news_sites/spiders/economynext.py
+++ b/Crawlers/news_sites/spiders/economynext.py
@@ -1,4 +1,6 @@
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -36,7 +38,12 @@ class EconomyNextSpider(scrapy.Spider):
         item['title'] = response.css('.article-title::text').extract_first()
         date  = response.css('.article-title+ h2::text').extract_first()
         if date is not None:
-            item['date'] = date.split('|')[0]
+            # extract date component and generalize it
+            date = date.split('|')[0]
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        
+            item['date'] = date
         else:
             item['date'] = None
         item['imageLink'] = response.css('.article-photo .set-image-border::attr(src)').extract_first()

--- a/Crawlers/news_sites/spiders/ft.py
+++ b/Crawlers/news_sites/spiders/ft.py
@@ -1,4 +1,6 @@
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -39,12 +41,15 @@ class FtSpider(scrapy.Spider):
 
         item['author'] = 'FT'
         item['title'] = response.css('.inner-header::text').extract_first()
-        date  = response.css('.inner-ft-text img::text').extract_first()
+        date = ''.join(response.css('.inner-other::text').extract())
         if date is not None:
-            item['date'] = date.split('/')[-1]
+            date = date.split('/')[-1]
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+            item['date'] = date
         else:
             item['date'] = None
-        item['imageLink'] = response.css('.article-photo .set-image-border::attr(src)').extract_first()
+        item['imageLink'] = response.css('.inner-ft-text img::attr(src)').extract_first()
         item['source'] = 'http://ft.lk/'
         item['content'] = ' \n '.join(response.css('.inner-ft-text p::text').extract())
 

--- a/Crawlers/news_sites/spiders/lankadeepa.py
+++ b/Crawlers/news_sites/spiders/lankadeepa.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import scrapy
-from scrapy.http import Request
+import dateutil.parser as dparser
 
 from ..items import NewsSitesItem
 
@@ -11,8 +11,20 @@ class LankadeepaSpider(scrapy.Spider):
     start_urls = ['http://www.lankadeepa.lk/latest_news/1']
 
     def parse(self, response):
-        for news_url in response.css('.news-title::attr("href")').extract():
-            yield response.follow(news_url, callback=self.parse_article)
+
+        # fetch news urls from each page
+        news_urls = response.css('.simple-thumb')
+
+        # iterate in news_urls
+        for news_url in news_urls:
+            # fetch url to main news page
+            url = news_url.css('.news-title::attr("href")').extract_first()
+
+            # fetch image url from main page as no image is present in article
+            img_url = news_url.css('.thubs-img::attr(src)').extract_first()
+
+            # follow the url of news article and fetch news data from it
+            yield response.follow(url, callback=self.parse_article, meta={'img_url': img_url})
 
         next_page = response.css('.page-numbers::attr("href")').extract_first()
         if next_page is not None:
@@ -23,8 +35,14 @@ class LankadeepaSpider(scrapy.Spider):
 
         item['author'] = 'http://www.lankadeepa.lk'
         item['title'] = response.css('.post-title::text').extract_first()
-        item['date']  = response.css('.post-date::text').extract_first()
-        item['imageLink'] = None
+        # extract date component and generalize it
+        date  = response.css('.post-date::text').extract_first()
+        if date is not None:
+            date = date.split('/')[-1]
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
+        item['imageLink'] = response.meta.get('img_url')
         item['source'] = 'http://www.lankadeepa.lk'
         item['content'] = ' \n '.join(response.css('.post-content p::text').extract())
 

--- a/Crawlers/news_sites/spiders/nf.py
+++ b/Crawlers/news_sites/spiders/nf.py
@@ -1,4 +1,6 @@
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -33,12 +35,19 @@ class NewsFirstSpider(scrapy.Spider):
     def parse_article(self, response):
         item = NewsSitesItem()
 
-        item['author'] = response.css('.artical-new-byline::text').extract_first()
-        item['title'] = response.css('.artical-hd-out::text').extract_first()
+        author = response.css('.artical-new-byline::text').extract_first()
+        title = response.css('.artical-hd-out::text').extract_first()
+        item['author'] = " ".join(author.split())
+        item['title'] = " ".join(title.split())
         if response.css('.artical-new-byline::text').extract() and response.css('.artical-new-byline::text').extract()[1]:
-            item['date']  = response.css('.artical-new-byline::text').extract()[1]
+            date = response.css('.artical-new-byline::text').extract()[1]
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+            item['date'] = date
+        else:
+            item['date'] = None
         item['imageLink'] = response.css('.main-news-block-artical .img-responsive::attr(src)').extract_first()
         item['source'] = 'https://www.newsfirst.lk'
-        item['content'] = ' \n '.join(response.css('.editor-styles p::text').extract())
+        item['content'] = '\n'.join(response.css('.editor-styles p::text').extract())
 
         yield item

--- a/Crawlers/news_sites/spiders/reporter.py
+++ b/Crawlers/news_sites/spiders/reporter.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -37,7 +39,11 @@ class ReporterSpider(scrapy.Spider):
 
         item['author'] = 'http://www.reporter.lk/'
         item['title'] = response.css('.entry-title::text').extract_first()
-        item['date']  = response.css('.timeago::text').extract_first()
+        date  = response.css('.timeago::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = response.css('#Blog1 img::attr(src)').extract_first()
         item['source'] = 'http://www.reporter.lk/'
         item['content'] = ' \n '.join(response.css('.entry-content::text').extract())

--- a/Crawlers/news_sites/spiders/rm.py
+++ b/Crawlers/news_sites/spiders/rm.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -35,9 +37,13 @@ class ReadmelkSpider(scrapy.Spider):
 
         item['author'] = response.css('.td-post-title a::text').extract_first()
         item['title'] = response.css('.td-post-title .entry-title::text').extract_first()
-        item['date']  = response.css('.td-post-date-no-dot .td-module-date::text').extract_first()
+        date = response.css('.td-post-date-no-dot .td-module-date::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = response.css('.article-photo .set-image-border::attr(src)').extract_first()
         item['source'] = 'http://www.readme.lk/'
-        item['content'] = ' \n '.join(response.css('h2 , .td-post-content p::text').extract())
+        item['content'] = '\n'.join(response.css('h2 , .td-post-content p::text').extract())
 
         yield item

--- a/Crawlers/news_sites/spiders/roar.py
+++ b/Crawlers/news_sites/spiders/roar.py
@@ -8,6 +8,13 @@ class RoarSpider(scrapy.Spider):
     name = "roar"
     allowed_domains = ["roar.lk"]
     start_urls = ['https://roar.media/english/life/', 'https://roar.media/english/tech/']
+    
+    def __init__(self, date=None):
+        if date is not None:
+            self.dateToMatch = dparser.parse(date,fuzzy=True).date()
+        else:
+            self.dateToMatch = None
+
     def parse(self, response):
         # extract news urls from news section
         temp = response.css('.withGrid > a::attr(href)').extract()
@@ -30,10 +37,19 @@ class RoarSpider(scrapy.Spider):
         item['author'] = response.css('#articleAuthor::text').extract_first()
         item['title'] = response.css('.title::text').extract_first()
         date  = response.css('#articleDate::text').extract_first()
-        if date is not None:
-            date = dparser.parse(date,fuzzy=True)
-            date = date.strftime("%d %B, %Y")
-        item['date'] = date
+        if date is None:
+            return
+        
+        date = date.replace("\r", "")
+        date = date.replace("\t", "")
+        date = date.replace("\n", "")
+        date = dparser.parse(date,fuzzy=True).date()
+        
+        # don't add news if we are using dateToMatch and date of news 
+        if self.dateToMatch is not None and self.dateToMatch != date:
+            return
+
+        item['date'] = date.strftime("%d %B, %Y")
         item['imageLink'] = None
         item['source'] = 'https://roar.media'
         item['content'] = '\n'.join(response.css('#article-body h2 , .inner-article-body > p::text').extract())

--- a/Crawlers/news_sites/spiders/roar.py
+++ b/Crawlers/news_sites/spiders/roar.py
@@ -1,4 +1,6 @@
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -27,9 +29,13 @@ class RoarSpider(scrapy.Spider):
 
         item['author'] = response.css('#articleAuthor::text').extract_first()
         item['title'] = response.css('.title::text').extract_first()
-        item['date']  = response.css('#articleDate::text').extract_first()
+        date  = response.css('#articleDate::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = None
         item['source'] = 'https://roar.media'
-        item['content'] = ' \n '.join(response.css('#article-body h2 , .inner-article-body > p::text').extract())
+        item['content'] = '\n'.join(response.css('#article-body h2 , .inner-article-body > p::text').extract())
 
         yield item

--- a/Crawlers/news_sites/spiders/slg.py
+++ b/Crawlers/news_sites/spiders/slg.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import scrapy
+import dateutil.parser as dparser
+
 from ..items import NewsSitesItem
 
 
@@ -19,17 +21,38 @@ class slgurdianSpider(scrapy.Spider):
         for news_url in news_urls:
             yield response.follow(news_url, callback=self.parse_article)
 
-        next_page = response.css('.fa-angle-double-right').xpath('../@href').extract_first()
+        next_page = response.css('blog-pager-older-link::attr(href)').extract_first()
+        
         if next_page is not None:
-            yield response.follow(next_page, callback=self.parse)
+            yield response.follow(next_page, callback=self.parse_page)
 
 
+    def parse_page(self, response):
+        
+        # extract news urls from news section
+        temp = response.css('.entry-title a::attr(href)').extract()
+
+        # remove duplicate urls
+        news_urls = []
+        [news_urls.append(x) for x in temp if x not in news_urls]
+
+        for news_url in news_urls:
+            yield response.follow(news_url, callback=self.parse_article)
+
+        next_page = response.css('.fa-angle-double-right').xpath('../@href').extract_first()
+        
+        if next_page is not None:
+            yield response.follow(next_page, callback=self.parse_page)
     def parse_article(self, response):
         item = NewsSitesItem()
 
         item['author'] = response.css('.entry-content div div b::text').extract_first()
         item['title'] = response.css('.entry-title::text').extract_first()
-        item['date']  = response.css('.published::text').extract_first()
+        date  = response.css('.published::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = response.css('#Blog1 img::attr(src)').extract_first()
         item['source'] = 'http://www.srilankaguardian.org'
         item['content'] = ' \n '.join(response.css('.entry-content div::text').extract())

--- a/Crawlers/news_sites/spiders/thepapare.py
+++ b/Crawlers/news_sites/spiders/thepapare.py
@@ -5,7 +5,7 @@ from ..items import NewsSitesItem
 
 
 class ThePapareSpider(scrapy.Spider):
-    name = "ThePapare"
+    name = "thepapare"
     allowed_domains = ["thepapare.com"]
     start_urls = ['http://www.thepapare.com/latest-news']
 
@@ -30,9 +30,13 @@ class ThePapareSpider(scrapy.Spider):
 
         item['author'] = response.css('.td-post-author-name a::text').extract_first()
         item['title'] = response.css('.td-post-title .entry-title::text').extract_first()
-        item['date']  = response.css('.td-post-title .td-module-date::text').extract_first()
+        date = response.css('.td-post-title .td-module-date::text').extract_first()
+        if date is not None:
+            date = dparser.parse(date,fuzzy=True)
+            date = date.strftime("%d %B, %Y")
+        item['date'] = date
         item['imageLink'] = response.css('.td-modal-image .td-animation-stack-type0-1::attr(src)').extract_first()
         item['source'] = 'http://www.thepapare.com'
-        item['content'] = ' \n '.join(response.css('.td-post-content p::text').extract())
+        item['content'] = '\n'.join(response.css('.td-post-content p::text').extract())
 
         yield item

--- a/Crawlers/requirements.txt
+++ b/Crawlers/requirements.txt
@@ -2,3 +2,4 @@ scrapy==1.6.0
 ScrapyElasticSearch==0.9.1
 scrapyd==1.2.0
 Twisted==18.9.0
+python-dateutil==2.8.0

--- a/fact-bounty-flask/api/crawler/views.py
+++ b/fact-bounty-flask/api/crawler/views.py
@@ -9,3 +9,9 @@ blueprint.add_url_rule(
     view_func=crawlerController['setcronjob'],
     methods=['GET', 'POST', 'PUT', 'DELETE']
 )
+
+blueprint.add_url_rule(
+    '/crawl_live',
+    view_func=crawlerController['crawlbydate'],
+    methods=['POST']
+)


### PR DESCRIPTION
- Generalize date component of news
- Add optional argument 'date' to spiders
- Implement new API route "/crawl_live" to add news of particular date or today to DB

Minor fixes:
- Add dependency python-dateutil to requirements of scrapy
- Fix minor issues in spiders
- Changed ctoday spider to fetch data from API instead of the webpage