### PR TITLE
Fixes SMTP send_email admin email env variable name

### DIFF
--- a/fact-bounty-flask/api/util/controller.py
+++ b/fact-bounty-flask/api/util/controller.py
@@ -27,7 +27,7 @@ class ContactUs(MethodView):
             """ % (email, message, phone)
 
             # send mail to admin
-            send_email(current_app.config['FLASKY_ADMIN'], subject, body)
+            send_email(current_app.config['FACTBOUNTY_ADMIN'], subject, body)
 
             response = {
                 'message': 'Form submitted Successfully!',


### PR DESCRIPTION
- This PR is a hot fix, which fixes the send email endpoint

Please note that we need to change this setting in out Fact Bounty email address to allow access:
https://stackoverflow.com/questions/16512592/login-credentials-not-working-with-gmail-smtp