### PR TITLE
removed react warnings

### DIFF
--- a/fact-bounty-client/src/components/ContactUsForm/ContactUsForm.jsx
+++ b/fact-bounty-client/src/components/ContactUsForm/ContactUsForm.jsx
@@ -9,11 +9,11 @@ class ContactUsForm extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      name: null,
-      email: null,
-      phone: null,
+      name: undefined,
+      email: undefined,
+      phone: undefined,
       subject: 'User - Contact Us',
-      message: null
+      message: undefined
     }
   }
 
@@ -85,7 +85,7 @@ class ContactUsForm extends Component {
             color="primary"
             style={{ width: 120, alignSelf: 'center', marginTop: 20 }}
             type="submit"
-            loading={loading}
+            loading={loading.toString()}
             disabled={loading}
           >
             SEND


### PR DESCRIPTION
There were some React warnings:
1. Value prop on input should not be null.
<b>Solution:</b> Change the default value of input props from null to undefined.
2. Received false for non-boolean attribute 'loading'
<b>Solution:</b> Convert boolean to string.