### PR TITLE
Add filter post type feature (UI + Logic)

### DIFF
--- a/fact-bounty-client/src/components/PostsList/PostsList.jsx
+++ b/fact-bounty-client/src/components/PostsList/PostsList.jsx
@@ -63,7 +63,7 @@ class PostsList extends Component {
     const filteredNotes = posts.filter(post => {
       let desiredCount = post[filterType]
       return (
-        Math.max(post.approved_count, post.mixedvote_count, post.fake_count) ==
+        Math.max(post.approved_count, post.mixedvote_count, post.fake_count) ===
         desiredCount
       )
     })
@@ -135,7 +135,4 @@ const mapDispatchToProps = dispatch => ({
   loadUserVotes: () => dispatch(loadUserVotes())
 })
 
-export default connect(
-  mapStatetoProps,
-  mapDispatchToProps
-)(PostsList)
+export default connect(mapStatetoProps, mapDispatchToProps)(PostsList)


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:
Added logic (handleFilter, filterNotesBy helper functions + map behavior change) and UI selector in order to filter notes by: All, True, Fake, and Mixed.

Calculated by matching the max vote value by the desired vote value.

Explain the **details** for making this change. What existing problem does the pull request solve?
Allows the user to view posts by type, leading to easier navigation and increased usability.

**Test plan (required)**
Tested by running with mock data:
![4Ms6qJheVA](https://user-images.githubusercontent.com/29003194/71647797-7fa83480-2cc9-11ea-81ad-b65cd3868fcf.gif)


**Code formatting**
Follows formatting conventions specified by Prettier.