### PR TITLE
[BUG FIX]: Error validation in register 

### DIFF
--- a/fact-bounty-client/src/pages/Register/Register.jsx
+++ b/fact-bounty-client/src/pages/Register/Register.jsx
@@ -192,7 +192,9 @@ class Register extends Component {
             className={this.props.classes.form}
           >
             <Typography component="span" variant="caption" color="error">
-              {typeof this.props.errors !== 'object' ? this.props.errors : null}
+              {typeof this.props.errors === 'object'
+                ? this.props.errors.message
+                : null}
             </Typography>
             <FormControl margin="normal" required fullWidth>
               <InputLabel htmlFor="name">Name</InputLabel>

--- a/fact-bounty-client/src/redux/actions/authActions.js
+++ b/fact-bounty-client/src/redux/actions/authActions.js
@@ -58,7 +58,7 @@ export const registerUser = (userData, history) => dispatch => {
       if (res.status === 202) {
         dispatch({
           type: GET_ERRORS,
-          payload: res.data.message
+          payload: { message: res.data.message }
         })
       } else {
         history.push('/login')


### PR DESCRIPTION
## Description
Both error messages are shown and no react error is being produced. Fixed by making payload as json object with key `message`.

**Preview**

<img src= "https://user-images.githubusercontent.com/42354803/72464887-2decc780-37fc-11ea-826d-129ce68e09a0.png" width="240px" height="300px">

**Closing issues**

Closes #496.