### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Run npm install in fact-bounty-client folder.
 
 *   #### Elasticsearch v7.6.0 can be installed as follows:
     ```
-        (venv)$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.0.deb
-        (venv)$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.0.deb.sha512
-        (venv)$ shasum -a 512 -c elasticsearch-7.6.0.deb.sha512
-        (venv)$ sudo dpkg -i elasticsearch-7.6.0.deb
+        (venv)$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.0-amd64.deb
+        (venv)$ wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.0-amd64.deb.sha512
+        (venv)$ shasum -a 512 -c elasticsearch-7.6.0-amd64.deb.sha512
+        (venv)$ sudo dpkg -i elasticsearch-7.6.0-amd64.deb
 
     ```
 


### PR DESCRIPTION
Updated Readme.md with a working link to Download Elasticsearch 7.6.0

![image](https://user-images.githubusercontent.com/23705245/77106834-c0505800-6a45-11ea-9a48-d8c0ef18e42e.png)
