### PR TITLE
Fixes localhost:9200 for elastic search server is not working issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Run npm install in fact-bounty-client folder.
     ```
         (venv)$ curl -X GET "localhost:9200/"
     ```
-    or open [https://localhost:9200](https://localhost:9200)
+    or open [http://localhost:9200](http://localhost:9200)
 
 ### How to Use
 


### PR DESCRIPTION
This pull request resolves issue #535.
Below is the attached screenshot of elasticsearch server running on `localhost:9200` after running the command `curl -X GET "localhost:9200/"`.

![Screenshot from 2020-03-29 17-40-14](https://user-images.githubusercontent.com/26167974/77848807-0b583100-71e5-11ea-91fb-d0fdbb218816.png)
