### PR TITLE
Fixed Issue #454 Login Glitch using Facebook and Google

### DIFF
--- a/fact-bounty-client/src/redux/actions/authActions.js
+++ b/fact-bounty-client/src/redux/actions/authActions.js
@@ -84,7 +84,7 @@ export const registerUser = (userData, history) => dispatch => {
 }
 
 export const OauthUser = creds => dispatch => {
-  AuthService.OauthUser(JSON.stringify(creds))
+  AuthService.OauthUser(creds)
     .then(res => {
       // Set token to localStorage
       const { access_token, refresh_token, user_details } = res.data

--- a/fact-bounty-flask/api/user/controller.py
+++ b/fact-bounty-flask/api/user/controller.py
@@ -284,6 +284,7 @@ class Auth(MethodView):
                 "message": "You logged in successfully.",
                 "access_token": access_token,
                 "refresh_token": refresh_token,
+                "user_details": user.to_json()
             }
             return make_response(jsonify(response)), 201
 
@@ -296,6 +297,7 @@ class Auth(MethodView):
                 "message": "You logged in successfully.",
                 "access_token": access_token,
                 "refresh_token": refresh_token,
+                "user_details": user.to_json()
             }
             return make_response(jsonify(response)), 202
 

--- a/fact-bounty-flask/api/user/model.py
+++ b/fact-bounty-flask/api/user/model.py
@@ -26,7 +26,7 @@ class User(Model):
     type = Column(db.String(50), default="remote")
     role = Column(db.String(10), default="user")
 
-    def __init__(self, name, email, password, role="user", _type="remote"):
+    def __init__(self, name, email, password=None, role="user", _type="remote"):
         """
         Initializes the user instance
         """


### PR DESCRIPTION
Bugfixes:
1. The existing code in authActions.js cause 404 error while logging in using facebook / google. Minor change is done to fix the issue.
2. Added user_details in controller.py to fix the missing user details after the user has logged into. Currently, if one is logged in using facebook/google, no user_details is present, resulting in no name at the dashboard.
3. Made password as an optional argument in model.py because when user will login using facebook/google, it won't contain a password for the user.

Fixes Issue #454 